### PR TITLE
Use the Gruntfile for the build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/lib/index.d.ts",
   "scripts": {
     "test": "jest --config=jest.config.json",
-    "prepublish": "tsc"
+    "prepublish": "grunt"
   },
   "keywords": [
     "gherkin",


### PR DESCRIPTION
👋 hey Stewart!

Just find out this repository as I was speaking with colleagues how neat it would be to run tests written in Gherkin with Jest: this is amazing, I'm stoked! 👏 

As I was trying to run the local tests, I figured out that the new parser wasn't included in the build step: I've just replaced the typescript compiler by grunt to run the `Gruntfile` you've added! 😳 

This project is super exciting!