### PR TITLE
Add support for tables as multiline arguments; Add support for hashtag comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,42 @@ The handler functions get two parameters:
 
 You can use the attributes parameter to do custom setup behaviour depending on attributes set on the test.  Note that a scenario
 gets the attributes from both the feature and that scenario.
+
+### Multiline tabular data
+
+You can define data tables in your specs with
+```gherkin
+Feature: Using tables
+  Scenario: lots of data
+    Given lots of data
+      | Header 1 | Header 2 | Header 3 |
+      | Value 1a | Value 1b | Value 1c |
+      | Value 2a | Value 2b | Value 2c |
+    When I use 3 key-value pairs
+      | Key 1 | Value 1 |
+      | Key 2 | Value 2 |
+      | Key 3 | Value 3 |
+    Then I can access all that data
+```
+
+And write rules for them like so
+```js
+cucumber.defineRule(/^lots of data$/, (world, table) => {
+  expect(table.hash['Header 2']).toEqual([ 'Value 1b', 'Value 2b' ])
+  expect(table.raw).toEqual([
+     [ 'Header 1', 'Header 2', 'Header 3' ],
+     [ 'Value 1a', 'Value 1b', 'Value 1c' ],
+     [ 'Value 2a', 'Value 2b', 'Value 2c' ],
+  ])
+});
+
+cucumber.defineRule(/^I use (\d+) key-value pairs$/, (world, number, table) => {
+  expect(number).toEqual(3)
+  expect(table.rowHash['Key 2']).toEqual('Value 2')
+  expect(table.raw).toEqual([
+    [ 'Key 1', 'Value 1' ],
+    [ 'Key 2', 'Value 2' ],
+    [ 'Key 3', 'Value 3' ],
+  ])
+});
+```

--- a/src/lib/cucumber.ts
+++ b/src/lib/cucumber.ts
@@ -1,3 +1,4 @@
+import FormattedTableData from './formatted-table-data'
 export interface RuleHandler {
   (world: any, ...args: any[]): any;
 }
@@ -111,9 +112,9 @@ export default class Cucumber {
       const match = str.match(rule.regex);
 
       if (match) {
-        const params = match.slice(1)
+        const params: Array<string | FormattedTableData>  = match.slice(1)
         if(table) {
-          params.push(table)
+          params.push(new FormattedTableData(table))
         }
         return Promise.resolve(rule.handler(world, ...params));
       }

--- a/src/lib/cucumber.ts
+++ b/src/lib/cucumber.ts
@@ -106,12 +106,16 @@ export default class Cucumber {
     this._createWorld = _createWorld;
   }
 
-  rule(world: any, str: string): any {
+  rule(world: any, str: string, table?: any): any {
     for (const rule of this.rules) {
       const match = str.match(rule.regex);
 
       if (match) {
-        return Promise.resolve(rule.handler(world, ...match.slice(1)));
+        const params = match.slice(1)
+        if(table) {
+          params.push(table)
+        }
+        return Promise.resolve(rule.handler(world, ...params));
       }
     }
 

--- a/src/lib/formatted-table-data.ts
+++ b/src/lib/formatted-table-data.ts
@@ -1,0 +1,36 @@
+export type RawData = string[][]
+
+export interface ColumnalData {
+  [key: string]: string[]
+}
+
+export interface KeyValueData {
+  [key: string]: string
+}
+
+export default class FormattedTableData {
+  constructor(private _data: RawData) { }
+  
+  get raw() { return this._data }
+
+  get hash(): ColumnalData {
+    const [
+      headers,
+      ...body
+    ] = this._data
+    const result = {}
+    headers.map((header, i) => {
+      result[header] = body.map(row => row[i])
+    })  
+    return result
+  }
+
+  get rowHash(): KeyValueData {
+    const result = {}
+    this._data.map(row => {
+      const [ key, value ] = row 
+      result[key] = value
+    })  
+    return result
+  }
+}

--- a/src/lib/parser.d.ts
+++ b/src/lib/parser.d.ts
@@ -7,8 +7,13 @@ export interface Feature {
 
 export interface Scenario {
   name: Clause;
-  rules: Clause[];
+  rules: Rule[];
   annotations: string[];
+}
+
+export interface Rule {
+  rule: String;
+  table?: Clause[][];
 }
 
 export type Clause = string;

--- a/src/lib/parser.pegjs
+++ b/src/lib/parser.pegjs
@@ -1,6 +1,9 @@
 {
   function expandTemplateString(template, example) {
-    return template.replace(/<([^>]+)>/g, (_, key) => example[key]);
+    const isScenario = typeof template !== 'object'
+    const templateString = isScenario ? template : template.rule
+    const expanded = templateString.replace(/<([^>]+)>/g, (_, key) => example[key])
+    return isScenario ? expanded : { rule: expanded };
   }
 
   function zip(keys, values) {
@@ -72,8 +75,8 @@ Rules
   { return rules }
 
 Rule
-  = _ Clause rule:String NL
-  { return rule }
+  = _ Clause rule:String NL table:Table
+  { return table.length ? { rule, table } : { rule } }
 
 Clause
   = TGiven
@@ -146,6 +149,7 @@ _ = WS Comment _
   / WS
 
 Comment = "//" String NL
+  / "#" String NL
 
 WS "whitespace"
   = [ \t\n\r]*

--- a/src/lib/process.ts
+++ b/src/lib/process.ts
@@ -13,7 +13,7 @@ ${jestFn('describe', feature.annotations)}("Feature: " + ${JSON.stringify(featur
   ${jestFn('it', scenario.annotations)}(${JSON.stringify(scenario.name)}, co.wrap(function *() {
     const world = cucumber.createWorld();
     yield cucumber.enterScenario(world, ${JSON.stringify([...feature.annotations, ...scenario.annotations])});
-${scenario.rules.map((rule) => `    yield cucumber.rule(world, ${JSON.stringify(rule)});`).join('\n')}
+${scenario.rules.map(({ rule, table }) => `    yield cucumber.rule(world, ${JSON.stringify(rule)}${ table ? ', ' + JSON.stringify(table) : ''});`).join('\n')}
     yield cucumber.exitScenario(world, ${JSON.stringify([...feature.annotations, ...scenario.annotations])});
   }));`).join('')}
 });`;

--- a/src/test/cucumber.test.ts
+++ b/src/test/cucumber.test.ts
@@ -19,6 +19,15 @@ describe('Cucumber', () => {
     expect(rule3).not.toHaveBeenCalled();
   });
 
+  it('should properly handle tabular data', () => {
+    const cucumber = new Cucumber();
+    const rule1 = jest.fn();
+    cucumber.defineRule(/I have (\d+)/, rule1);
+    const tabularData = ['data']
+    cucumber.rule(null, 'I have 3', tabularData);
+    expect(rule1).toHaveBeenCalledWith(null, "3", tabularData);
+  })
+
   it('should support the string template style', () => {
     const cucumber = new Cucumber();
     const rule = jest.fn((world, str, int, float, word) => {

--- a/src/test/cucumber.test.ts
+++ b/src/test/cucumber.test.ts
@@ -19,13 +19,31 @@ describe('Cucumber', () => {
     expect(rule3).not.toHaveBeenCalled();
   });
 
-  it('should properly handle tabular data', () => {
+  it('should properly parse tabular data', () => {
     const cucumber = new Cucumber();
     const rule1 = jest.fn();
     cucumber.defineRule(/I have (\d+)/, rule1);
-    const tabularData = ['data']
+    const tabularData = [
+      [ 'a1', 'b1', 'c1' ],
+      [ 'a2', 'b2', 'c2' ],
+      [ 'a3', 'b3', 'c3' ]
+    ]
     cucumber.rule(null, 'I have 3', tabularData);
-    expect(rule1).toHaveBeenCalledWith(null, "3", tabularData);
+    expect(rule1.mock.calls[0][0]).toEqual(null)
+    expect(rule1.mock.calls[0][1]).toEqual("3")
+    const parsedTabularData = rule1.mock.calls[0][2]
+    expect(parsedTabularData.raw).toEqual(tabularData)
+    expect(parsedTabularData.hash).toEqual({
+      a1: [ 'a2', 'a3' ],
+      b1: [ 'b2', 'b3' ],
+      c1: [ 'c2', 'c3' ]
+    })
+
+    expect(parsedTabularData.rowHash).toEqual({
+      a1: 'b1',
+      a2: 'b2',
+      a3: 'b3'
+    })
   })
 
   it('should support the string template style', () => {

--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -28,15 +28,15 @@ describe("Parser", () => {
         {
           name: "this is a test",
           rules: [
-            "that I am testing",
-            "I am still testing",
-            "also that I test",
-            "I test",
-            "test",
-            "continue testing",
-            "I want to test",
-            "test",
-            "test"
+            { rule: "that I am testing" },
+            { rule: "I am still testing" },
+            { rule: "also that I test" },
+            { rule: "I test" },
+            { rule: "test" },
+            { rule: "continue testing" },
+            { rule: "I want to test" },
+            { rule: "test" },
+            { rule: "test" }
           ],
           annotations: []
         }
@@ -65,7 +65,11 @@ describe("Parser", () => {
       scenarios: [
         {
           name: "this is a scenario outline",
-          rules: ["that I have abc", "I 123", "I -£*%"],
+          rules: [ 
+            { rule: "that I have abc" },
+            { rule: "I 123" },
+            { rule: "I -£*%" }
+          ],
           annotations: []
         }
       ],
@@ -73,6 +77,68 @@ describe("Parser", () => {
     });
   });
 
+  it("should use hashtag for the comment character", () => {
+    const result = parse(
+      `
+      # foobar
+      Feature: foo
+        # comment
+        Scenario: this is a test
+          * a thing
+    `
+    );
+
+    expect(result).toEqual({
+      name: "foo",
+      scenarios: [
+        {
+          name: "this is a test",
+          rules: [
+            { rule: "a thing" }
+          ],
+          annotations: []
+        }
+      ],
+      annotations: []
+    });
+  });
+
+  it("should parse data tables", () => {
+    const result = parse(
+      `
+      Feature: foo
+        Scenario: test with data
+          Given some data
+            | Header1 | Header2 | Header3 |
+            | Cell1 | Cell2 | Cell3 |
+          Then something else
+    `
+    );
+
+    expect(result).toEqual({
+      name: "foo",
+      scenarios: [
+        {
+          name: "test with data",
+          rules: [
+            { 
+              rule: "some data",
+              table: [
+                [ 'Header1', 'Header2', 'Header3' ],
+                [ 'Cell1', 'Cell2', 'Cell3' ]
+              ]
+            },
+            {
+              rule: "something else"
+            }
+          ],
+          annotations: []
+        }
+      ],
+      annotations: []
+    });
+
+  })
 
   it("should parse a scenario with annotations", () => {
     const result = parse(
@@ -92,7 +158,7 @@ describe("Parser", () => {
         {
           name: "this is a test",
           rules: [
-            "a thing"
+            { rule: "a thing" }
           ],
           annotations: ["annotation2", "annotation3"]
         }

--- a/src/test/process.test.ts
+++ b/src/test/process.test.ts
@@ -12,6 +12,9 @@ describe('process', () => {
       @some-other-attribute
       Scenario: a scenario
         Given some givens
+          And some data
+            | Table Head 1 | Table Head 2 |
+            | Cell 1 | Cell 2|
         When I do a thing
         Then I will succeed
     `, '');
@@ -27,6 +30,7 @@ describe("Feature: " + "this is a test", () => {
     const world = cucumber.createWorld();
     yield cucumber.enterScenario(world, ["someAttribute","some-other-attribute"]);
     yield cucumber.rule(world, "some givens");
+    yield cucumber.rule(world, "some data", [["Table Head 1","Table Head 2"],["Cell 1","Cell 2"]]);
     yield cucumber.rule(world, "I do a thing");
     yield cucumber.rule(world, "I will succeed");
     yield cucumber.exitScenario(world, ["someAttribute","some-other-attribute"]);


### PR DESCRIPTION
This PR adds support for tables and hashtag comments. With this commit, the following is valid: 

````gherkin
Feature: tables and hashtag comments
  // Backward-compatible comments
  # Spec-compliant comments
  Scenario: with some data
    Given some data:
      | Heading | Another Heading |
      | Body | More Body |
````

The table data, if provided, is the final argument in the list of arguments in the rule definition
````js
cucumber.defineRule(/with params one: (\d+) and params two: (\d+) /, (world, one, two, table) => {
  .... etc.
}
````