### PR TITLE
export HookType from stucumber

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,2 +1,2 @@
-export {cucumber} from 'stucumber';
+export {cucumber, HookType} from 'stucumber';
 export {default as process} from './process';


### PR DESCRIPTION
What?
**HookTypes** are required to use `cucumber.addHook` but are not yet exported

How?
Export `HookType` from **stucumber**