### PR TITLE
fix: jest 27 support

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,2 +1,11 @@
+
+import {cucumber} from 'stucumber';
+import {default as process} from './process';
+
+export default {
+  cucumber,
+  process
+}
+
 export {cucumber} from 'stucumber';
 export {default as process} from './process';


### PR DESCRIPTION
Currently, Jest throws this error:

```
TypeError: Jest: a transform must export something.
    at /home/akryum/Projects/livestorm-app/node_modules/@jest/transform/build/ScriptTransformer.js:389:19
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Promise.all (index 1)
    at ScriptTransformer.loadTransformers (/home/akryum/Projects/livestorm-app/node_modules/@jest/transform/build/ScriptTransformer.js:378:5)
    at createScriptTransformer (/home/akryum/Projects/livestorm-app/node_modules/@jest/transform/build/ScriptTransformer.js:1109:3)
    at /home/akryum/Projects/livestorm-app/node_modules/@jest/core/build/runGlobalHook.js:121:27
    at pEachSeries (/home/akryum/Projects/livestorm-app/node_modules/p-each-series/index.js:8:3)
    at _default (/home/akryum/Projects/livestorm-app/node_modules/@jest/core/build/runGlobalHook.js:110:5)
    at runJest (/home/akryum/Projects/livestorm-app/node_modules/@jest/core/build/runJest.js:352:5)
    at _run10000 (/home/akryum/Projects/livestorm-app/node_modules/@jest/core/build/cli/index.js:408:7)
```

Because now it expects a default export from the transform.